### PR TITLE
Separated the media odata upload service into two capabilities... one…

### DIFF
--- a/src/AndcultureCode.CSharp.Sitefinity.Core/Services/CoreMediaODataServices.cs
+++ b/src/AndcultureCode.CSharp.Sitefinity.Core/Services/CoreMediaODataServices.cs
@@ -56,7 +56,7 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Services
         }
 
         /// <summary>
-        /// Updates the exiting model and uploads and overwrites the current media asset using the filePath asset provided
+        /// Updates the existing model and uploads and overwrites the current media asset using the filePath asset provided
         /// </summary>
         /// <param name="model"></param>
         /// <param name="filePath"></param>

--- a/src/AndcultureCode.CSharp.Sitefinity.Core/Services/CoreMediaODataServices.cs
+++ b/src/AndcultureCode.CSharp.Sitefinity.Core/Services/CoreMediaODataServices.cs
@@ -19,7 +19,7 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Services
         public CoreMediaODataServices(IODataConnectionSettings settings, ODataSession session) : base(settings, session) { }
 
         /// <summary>
-        /// Creates the new model and uploads the media asset using the appropriate service endpoint
+        /// Creates the new model and uploads the media asset using the filePath asset provided
         /// </summary>
         /// <param name="model"></param>
         /// <param name="filePath"></param>
@@ -56,7 +56,7 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Services
         }
 
         /// <summary>
-        /// Updates the exiting model and uploads the media asset using the appropriate service endpoint
+        /// Updates the exiting model and uploads and overwrites the current media asset using the filePath asset provided
         /// </summary>
         /// <param name="model"></param>
         /// <param name="filePath"></param>


### PR DESCRIPTION
… for uploading and creating and one for uploading and overwriting

#40 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)