### PR TITLE
Refactored sitefinity content model to use an Lstring type and the Ur…

### DIFF
--- a/src/AndcultureCode.CSharp.Sitefinity.Core/Models/Content/SitefinityContent.cs
+++ b/src/AndcultureCode.CSharp.Sitefinity.Core/Models/Content/SitefinityContent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Telerik.Sitefinity.GenericContent.Model;
+using Telerik.Sitefinity.Model;
 
 namespace AndcultureCode.CSharp.Sitefinity.Core.Models.Content
 {
@@ -14,6 +15,6 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Models.Content
         public Guid OriginalContentId { get; set; }
         public DateTime PublicationDate { get; set; }
         public ContentLifecycleStatus Status { get; set; }
-        public string SystemUrl { get; set; }
+        public Lstring UrlName { get; set; }
     }
 }

--- a/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
+++ b/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
@@ -42,10 +42,6 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             public DateTimeOffset TestDateTimeOffsetProperty { get; set; }
             public DateTimeOffset? TestNullableDateTimeOffsetProperty { get; set; }
             public string TestEnumProperty { get; set; }
-            [DataMember]
-            [MetadataMapping(true, false)]
-            [UserFriendlyDataType(UserFriendlyDataType.LongText)]
-            [CommonProperty]
             public Lstring TestLstringProperty { get; set; }
         }
 

--- a/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
+++ b/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
@@ -2,8 +2,6 @@
 using Shouldly;
 using System;
 using System.Globalization;
-using Telerik.OpenAccess;
-using Telerik.Sitefinity;
 using Telerik.Sitefinity.DynamicModules.Model;
 using Telerik.Sitefinity.Model;
 using Xunit;
@@ -147,7 +145,7 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             content.TestEnumProperty = null;
 
             // Act & Assert
-            var mappedContent = content.MapTo<TestValidClass>(); 
+            var mappedContent = content.MapTo<TestValidClass>();
         }
     }
 }

--- a/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
+++ b/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
@@ -150,8 +150,4 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             var mappedContent = content.MapTo<TestValidClass>(); 
         }
     }
-
-    internal class DataMemberAttribute : Attribute
-    {
-    }
 }

--- a/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
+++ b/test/AndcultureCode.CSharp.Sitefinity.Core.Tests/Unit/Extensions/DynamicContentExtensionsTests.cs
@@ -1,7 +1,11 @@
 ﻿using AndcultureCode.CSharp.Sitefinity.Core.Extensions;
 using Shouldly;
 using System;
+using System.Globalization;
+using Telerik.OpenAccess;
+using Telerik.Sitefinity;
 using Telerik.Sitefinity.DynamicModules.Model;
+using Telerik.Sitefinity.Model;
 using Xunit;
 
 namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
@@ -18,6 +22,7 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             public DateTimeOffset TestDateTimeOffsetProperty { get; set; }
             public DateTimeOffset? TestNullableDateTimeOffsetProperty { get; set; }
             public TestEnum TestEnumProperty { get; set; }
+            public Lstring TestLstringProperty { get; set; }
         }
 
         public class TestInvalidClass
@@ -37,6 +42,11 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             public DateTimeOffset TestDateTimeOffsetProperty { get; set; }
             public DateTimeOffset? TestNullableDateTimeOffsetProperty { get; set; }
             public string TestEnumProperty { get; set; }
+            [DataMember]
+            [MetadataMapping(true, false)]
+            [UserFriendlyDataType(UserFriendlyDataType.LongText)]
+            [CommonProperty]
+            public Lstring TestLstringProperty { get; set; }
         }
 
         public enum TestEnum
@@ -68,6 +78,7 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             content.TestStringProperty = "Test";
             content.TestDateTimeOffsetProperty = DateTimeOffset.Now;
             content.TestNullableDateTimeOffsetProperty = DateTimeOffset.Now;
+            content.TestLstringProperty = new Lstring("test", new CultureInfo("en"));
 
             // Act
             var mappedContent = content.MapTo<TestValidClass>();
@@ -78,6 +89,7 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             mappedContent.TestStringProperty.ShouldBe(content.TestStringProperty);
             mappedContent.TestDateTimeOffsetProperty.ShouldBe(content.TestDateTimeOffsetProperty);
             mappedContent.TestNullableDateTimeOffsetProperty.ShouldBe(content.TestNullableDateTimeOffsetProperty);
+            mappedContent.TestLstringProperty.ShouldBe(content.TestLstringProperty);
         }
 
         [Fact]
@@ -141,6 +153,9 @@ namespace AndcultureCode.CSharp.Sitefinity.Core.Tests.Unit.Extensions
             // Act & Assert
             var mappedContent = content.MapTo<TestValidClass>(); 
         }
+    }
 
+    internal class DataMemberAttribute : Attribute
+    {
     }
 }


### PR DESCRIPTION
…lName instead of the SystemUrl which is only a dynamic content mode property and updated the tests to cover it
#44 
- [X] Related GitHub issue(s) linked in PR description
- [X] Destination branch merged, built and tested with your changes
- [X] Code formatted and follows best practices and patterns
- [X] Code builds cleanly (no _additional_ warnings or errors)
- [X] Manually tested
- [X] Automated tests are passing
- [X] No _decreases_ in automated test coverage
- [X] Documentation updated (readme, docs, comments, etc.)